### PR TITLE
up version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,12 +2,15 @@
 [PR #25](https://github.com/fivetran/dbt_greenhouse/pull/25) is a breaking change due to [upstream updates](
 https://github.com/fivetran/dbt_greenhouse_source/blob/main/CHANGELOG.md#dbt_greenhouse_source-v070):
 
+## Upstream Changes
 - Updated the logic for `stg_greenhouse__tag` and `stg_greenhouse__user` to account for the presence of the singularly or plurally-named titular source tables, tag(s) and user(s).
   - The source table `tag` was renamed to `tags` for [connectors created on or after July 18, 2024](https://fivetran.com/docs/connectors/applications/greenhouse/changelog#july2024) and the table `user` was renamed to `users` in [October 2024](https://fivetran.com/docs/connectors/applications/greenhouse/changelog#october2024).
 - This is a breaking change for customers with the plurally-named tables, as they have not been able to run the models previously.
 
-For more information, refer to the upstream [CHANGELOG.](
-https://github.com/fivetran/dbt_greenhouse_source/blob/main/CHANGELOG.md#dbt_greenhouse_source-v070)
+- For more information, refer to the upstream [CHANGELOG.](https://github.com/fivetran/dbt_greenhouse_source/blob/main/CHANGELOG.md#dbt_greenhouse_source-v070)
+
+## Under the Hood
+- Added validation tests under the `integration_tests/tests` folder.
 
 # dbt_greenhouse v0.6.0
 ## 🎉 Feature Update 🎉

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+# dbt_greenhouse v0.7.0
+
 # dbt_greenhouse v0.6.0
 ## 🎉 Feature Update 🎉
 - Databricks and PostgreSQL compatibility! ([#19](https://github.com/fivetran/dbt_greenhouse/pull/19))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # dbt_greenhouse v0.7.0
+[PR #25](https://github.com/fivetran/dbt_greenhouse/pull/25) is a breaking change due to [upstream updates](
+https://github.com/fivetran/dbt_greenhouse_source/blob/main/CHANGELOG.md#dbt_greenhouse_source-v070):
+
+- Updated the logic for `stg_greenhouse__tag` and `stg_greenhouse__user` to account for the presence of the singularly or plurally-named titular source tables, tag(s) and user(s).
+- This is a breaking change for customers with the plurally-named tables, as they have not been able to run the models previously.
+
+For more information, refer to the upstream [CHANGELOG.](
+https://github.com/fivetran/dbt_greenhouse_source/blob/main/CHANGELOG.md#dbt_greenhouse_source-v070)
 
 # dbt_greenhouse v0.6.0
 ## 🎉 Feature Update 🎉

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 https://github.com/fivetran/dbt_greenhouse_source/blob/main/CHANGELOG.md#dbt_greenhouse_source-v070):
 
 - Updated the logic for `stg_greenhouse__tag` and `stg_greenhouse__user` to account for the presence of the singularly or plurally-named titular source tables, tag(s) and user(s).
+  - The source table `tag` was renamed to `tags` for [connectors created on or after July 18, 2024](https://fivetran.com/docs/connectors/applications/greenhouse/changelog#july2024) and the table `user` was renamed to `users` in [October 2024](https://fivetran.com/docs/connectors/applications/greenhouse/changelog#october2024).
 - This is a breaking change for customers with the plurally-named tables, as they have not been able to run the models previously.
 
 For more information, refer to the upstream [CHANGELOG.](

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Include the following greenhouse package version in your `packages.yml` file:
 ```yaml
 packages:
   - package: fivetran/greenhouse
-    version: [">=0.6.0", "<0.7.0"]
+    version: [">=0.7.0", "<0.8.0"]
 ```
 
 ### Step 3: Define database and schema variables
@@ -135,7 +135,7 @@ packages:
       version: [">=1.0.0", "<2.0.0"]
 
     - package: fivetran/greenhouse_source
-      version: [">=0.6.0", "<0.7.0"]
+      version: [">=0.7.0", "<0.8.0"]
 ```
 
 ## How is this package maintained and can I contribute?

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'greenhouse'
-version: 0.6.0
+version: 0.7.0
 config-version: 2
 require-dbt-version: [">=1.3.0", "<2.0.0"]
 vars:

--- a/integration_tests/ci/sample.profiles.yml
+++ b/integration_tests/ci/sample.profiles.yml
@@ -16,13 +16,13 @@ integration_tests:
       pass: "{{ env_var('CI_REDSHIFT_DBT_PASS') }}"
       dbname: "{{ env_var('CI_REDSHIFT_DBT_DBNAME') }}"
       port: 5439
-      schema: greenhouse_integration_tests_03
+      schema: greenhouse_integration_tests_05
       threads: 8
     bigquery:
       type: bigquery
       method: service-account-json
       project: 'dbt-package-testing'
-      schema: greenhouse_integration_tests_03
+      schema: greenhouse_integration_tests_05
       threads: 8
       keyfile_json: "{{ env_var('GCLOUD_SERVICE_KEY') | as_native }}"
     snowflake:
@@ -33,7 +33,7 @@ integration_tests:
       role: "{{ env_var('CI_SNOWFLAKE_DBT_ROLE') }}"
       database: "{{ env_var('CI_SNOWFLAKE_DBT_DATABASE') }}"
       warehouse: "{{ env_var('CI_SNOWFLAKE_DBT_WAREHOUSE') }}"
-      schema: greenhouse_integration_tests_03
+      schema: greenhouse_integration_tests_05
       threads: 8
     postgres:
       type: postgres
@@ -42,13 +42,13 @@ integration_tests:
       pass: "{{ env_var('CI_POSTGRES_DBT_PASS') }}"
       dbname: "{{ env_var('CI_POSTGRES_DBT_DBNAME') }}"
       port: 5432
-      schema: greenhouse_integration_tests_03
+      schema: greenhouse_integration_tests_05
       threads: 8
     databricks:
       catalog: "{{ env_var('CI_DATABRICKS_DBT_CATALOG') }}"
       host: "{{ env_var('CI_DATABRICKS_DBT_HOST') }}"
       http_path: "{{ env_var('CI_DATABRICKS_DBT_HTTP_PATH') }}"
-      schema: greenhouse_integration_tests_03
+      schema: greenhouse_integration_tests_05
       threads: 8
       token: "{{ env_var('CI_DATABRICKS_DBT_TOKEN') }}"
       type: databricks

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -2,8 +2,13 @@ name: 'greenhouse_integration_tests'
 version: 0.7.0
 config-version: 2
 profile: 'integration_tests'
+
+
+models:
+  +schema: "greenhouse_{{ var('directed_schema','dev') }}"
+
 vars:
-  greenhouse_schema: greenhouse_integration_tests_03
+  greenhouse_schema: greenhouse_integration_tests_05
   greenhouse_source:
     greenhouse_activity_identifier: "activity"
     greenhouse_pplication_identifier: "application"
@@ -43,9 +48,6 @@ vars:
   greenhouse_using_app_history: true
   greenhouse_using_prospects: true
 
-
-models:
-  +schema: "greenhouse_{{ var('directed_schema','dev') }}"
 
 seeds:
   greenhouse_integration_tests:

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -42,6 +42,11 @@ vars:
   greenhouse_using_eeoc: true
   greenhouse_using_app_history: true
   greenhouse_using_prospects: true
+
+
+models:
+  +schema: "greenhouse_{{ var('directed_schema','dev') }}"
+
 seeds:
   greenhouse_integration_tests:
     +column_types:

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'greenhouse_integration_tests'
-version: 0.6.0
+version: 0.7.0
 config-version: 2
 profile: 'integration_tests'
 vars:

--- a/integration_tests/tests/consistency/consistency_application_enhanced.sql
+++ b/integration_tests/tests/consistency/consistency_application_enhanced.sql
@@ -1,0 +1,45 @@
+{{ config(
+    tags="fivetran_validations",
+    enabled=var('fivetran_validation_tests_enabled', false)
+) }}
+
+with prod as (
+    select *
+    from {{ target.schema }}_greenhouse_prod.greenhouse__application_enhanced
+),
+
+dev as (
+    select *
+    from {{ target.schema }}_greenhouse_dev.greenhouse__application_enhanced
+), 
+
+prod_not_in_dev as (
+    -- rows from prod not found in dev
+    select * from prod
+    except distinct
+    select * from dev
+),
+
+dev_not_in_prod as (
+    -- rows from dev not found in prod
+    select * from dev
+    except distinct
+    select * from prod
+),
+
+final as (
+    select
+        *,
+        'from prod' as source
+    from prod_not_in_dev
+
+    union all -- union since we only care if rows are produced
+
+    select
+        *,
+        'from dev' as source
+    from dev_not_in_prod
+)
+
+select *
+from final

--- a/integration_tests/tests/consistency/consistency_application_history.sql
+++ b/integration_tests/tests/consistency/consistency_application_history.sql
@@ -1,0 +1,46 @@
+{{ config(
+    tags="fivetran_validations",
+    enabled=var('fivetran_validation_tests_enabled', false)
+) }}
+
+with prod as (
+
+    select *
+    from {{ target.schema }}_greenhouse_prod.greenhouse__application_history
+),
+
+dev as (
+    select *
+    from {{ target.schema }}_greenhouse_dev.greenhouse__application_history
+), 
+
+prod_not_in_dev as (
+    -- rows from prod not found in dev
+    select * from prod
+    except distinct
+    select * from dev
+),
+
+dev_not_in_prod as (
+    -- rows from dev not found in prod
+    select * from dev
+    except distinct
+    select * from prod
+),
+
+final as (
+    select
+        *,
+        'from prod' as source
+    from prod_not_in_dev
+
+    union all -- union since we only care if rows are produced
+
+    select
+        *,
+        'from dev' as source
+    from dev_not_in_prod
+)
+
+select *
+from final

--- a/integration_tests/tests/consistency/consistency_interview_enhanced.sql
+++ b/integration_tests/tests/consistency/consistency_interview_enhanced.sql
@@ -1,0 +1,45 @@
+{{ config(
+    tags="fivetran_validations",
+    enabled=var('fivetran_validation_tests_enabled', false)
+) }}
+
+with prod as (
+    select *
+    from {{ target.schema }}_greenhouse_prod.greenhouse__interview_enhanced
+),
+
+dev as (
+    select *
+    from {{ target.schema }}_greenhouse_dev.greenhouse__interview_enhanced
+), 
+
+prod_not_in_dev as (
+    -- rows from prod not found in dev
+    select * from prod
+    except distinct
+    select * from dev
+),
+
+dev_not_in_prod as (
+    -- rows from dev not found in prod
+    select * from dev
+    except distinct
+    select * from prod
+),
+
+final as (
+    select
+        *,
+        'from prod' as source
+    from prod_not_in_dev
+
+    union all -- union since we only care if rows are produced
+
+    select
+        *,
+        'from dev' as source
+    from dev_not_in_prod
+)
+
+select *
+from final

--- a/integration_tests/tests/consistency/consistency_interview_scorecard_detail.sql
+++ b/integration_tests/tests/consistency/consistency_interview_scorecard_detail.sql
@@ -1,0 +1,45 @@
+{{ config(
+    tags="fivetran_validations",
+    enabled=var('fivetran_validation_tests_enabled', false)
+) }}
+
+with prod as (
+    select *
+    from {{ target.schema }}_greenhouse_prod.greenhouse__interview_scorecard_detail
+),
+
+dev as (
+    select *
+    from {{ target.schema }}_greenhouse_dev.greenhouse__interview_scorecard_detail
+), 
+
+prod_not_in_dev as (
+    -- rows from prod not found in dev
+    select * from prod
+    except distinct
+    select * from dev
+),
+
+dev_not_in_prod as (
+    -- rows from dev not found in prod
+    select * from dev
+    except distinct
+    select * from prod
+),
+
+final as (
+    select
+        *,
+        'from prod' as source
+    from prod_not_in_dev
+
+    union all -- union since we only care if rows are produced
+
+    select
+        *,
+        'from dev' as source
+    from dev_not_in_prod
+)
+
+select *
+from final

--- a/integration_tests/tests/consistency/consistency_job_enhanced.sql
+++ b/integration_tests/tests/consistency/consistency_job_enhanced.sql
@@ -1,0 +1,45 @@
+{{ config(
+    tags="fivetran_validations",
+    enabled=var('fivetran_validation_tests_enabled', false)
+) }}
+
+with prod as (
+    select *
+    from {{ target.schema }}_greenhouse_prod.greenhouse__job_enhanced
+),
+
+dev as (
+    select *
+    from {{ target.schema }}_greenhouse_dev.greenhouse__job_enhanced
+), 
+
+prod_not_in_dev as (
+    -- rows from prod not found in dev
+    select * from prod
+    except distinct
+    select * from dev
+),
+
+dev_not_in_prod as (
+    -- rows from dev not found in prod
+    select * from dev
+    except distinct
+    select * from prod
+),
+
+final as (
+    select
+        *,
+        'from prod' as source
+    from prod_not_in_dev
+
+    union all -- union since we only care if rows are produced
+
+    select
+        *,
+        'from dev' as source
+    from dev_not_in_prod
+)
+
+select *
+from final

--- a/packages.yml
+++ b/packages.yml
@@ -1,7 +1,3 @@
 packages:
-  # - package: fivetran/greenhouse_source
-  #   version: [">=0.7.0", "<0.8.0"]
-
-  - git: https://github.com/fivetran/dbt_greenhouse_source.git
-    revision: release/0.7.0
-    warn-unpinned: false
+  - package: fivetran/greenhouse_source
+    version: [">=0.7.0", "<0.8.0"]

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,7 @@
 packages:
-  - package: fivetran/greenhouse_source
-    version: [">=0.7.0", "<0.8.0"]
+  # - package: fivetran/greenhouse_source
+  #   version: [">=0.7.0", "<0.8.0"]
+
+  - git: https://github.com/fivetran/dbt_greenhouse_source.git
+    revision: release/0.7.0
+    warn-unpinned: false

--- a/packages.yml
+++ b/packages.yml
@@ -1,3 +1,3 @@
 packages:
- - package: fivetran/greenhouse_source
-   version: [">=0.6.0", "<0.7.0"]
+  - package: fivetran/greenhouse_source
+    version: [">=0.7.0", "<0.8.0"]


### PR DESCRIPTION
## PR Overview
**This PR will address the following Issue/Feature:**
internal ticket
https://github.com/fivetran/dbt_greenhouse_source/issues/27
https://github.com/fivetran/dbt_greenhouse_source/issues/26

**This PR will result in the following new package version:**
<!--- Please add details around your decision for breaking vs non-breaking version upgrade. If this is a breaking change, were backwards-compatible options explored? -->
v0.7.0

breaking since this may change the schema for those running into previous errors with `users` and `tags` source tables.

**Please provide the finalized CHANGELOG entry which details the relevant changes included in this PR:**
<!--- Copy/paste the CHANGELOG for this version below. -->

- Updated the logic for `stg_greenhouse__tag` and `stg_greenhouse__user` to account for the presence of the singularly or plurally-named titular source tables, tag(s) and user(s).
- This is a breaking change for customers with the plurally-named tables, as they have not been able to run the models previously.

For more information, refer to the upstream [CHANGELOG.](
https://github.com/fivetran/dbt_greenhouse_source/blob/main/CHANGELOG.md#dbt_greenhouse_source-v070)

## PR Checklist
### Basic Validation
Please acknowledge that you have successfully performed the following commands locally:
- [x] dbt run –full-refresh && dbt test
- [ ] dbt run (if incremental models are present) && dbt test

Before marking this PR as "ready for review" the following have been applied:
- [x] The appropriate issue has been linked, tagged, and properly assigned
- [x] All necessary documentation and version upgrades have been applied
- [not yet] docs were regenerated (unless this PR does not include any code or yml updates)
- [x] BuildKite integration tests are passing
- [x] Detailed validation steps have been provided below

### Detailed Validation
Please share any and all of your validation steps:
<!--- Provide the steps you took to validate your changes below. -->
I added new seed files for `users` and `tags`, which is differentiated by id's starting with 8 instead of 4 as in the original `user` and `tag` seed data. If you run with the following configs:

>     greenhouse_tag_identifier: "tag"
>     greenhouse_user_identifier: "user"
>     greenhouse_tags_identifier: "tags"
>     greenhouse_users_identifier: "users"


and separately switch to a new test schema and run with this config:


>     # greenhouse_tag_identifier: "tag"
>     # greenhouse_user_identifier: "user"
>     greenhouse_tags_identifier: "tags"
>     greenhouse_users_identifier: "users"

You'll find the `stg_greenhouse__tag` and `stg_greenhouse__user` running as expected for either scenario.

Additionally,
<img width="804" alt="image" src="https://github.com/user-attachments/assets/746e5420-c309-49cf-af67-e2c43f74d076">


### If you had to summarize this PR in an emoji, which would it be?
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
:dancer: